### PR TITLE
Fix taxonomy parser and dataset utilities

### DIFF
--- a/amplikraken/fastq.py
+++ b/amplikraken/fastq.py
@@ -39,7 +39,7 @@ class FastqDataset:
             return f"SE:{self.name} -> {fwd}"
         
     def __repr__(self) -> str:
-        f"FastqDataset({self.name}, {self.forward}, {self.reverse})"
+        return f"FastqDataset({self.name}, {self.forward}, {self.reverse})"
         
     def _update(self):
         if self.forward is not None and os.path.isfile(self.forward):
@@ -65,8 +65,9 @@ class FastqDataset:
             self.valid = False
 
     def __eq__(self, __value: object) -> bool:
-        if self.forward == __value.forward and self.reverse == __value.reverse:
-            return True
+        if isinstance(__value, FastqDataset):
+            return self.forward == __value.forward and self.reverse == __value.reverse
+        return NotImplemented
         
     
     def __lt__(self, __value: object) -> bool:

--- a/amplikraken/kraken.py
+++ b/amplikraken/kraken.py
@@ -147,8 +147,10 @@ def taxonomy_splitter(taxonomy_string):
     # Check if taxid is an integer
     try:
         taxid = int(taxonomy_string[1])
-    except:
-        raise Exception(f"Error parsing taxonomy string {taxonomy_string}: taxid {taxid} is not an integer")
+    except ValueError:
+        raise Exception(
+            f"Error parsing taxonomy string {taxonomy_string}: taxid {taxonomy_string[1]} is not an integer"
+        )
     
     return taxid, taxonomy_string[0]
     

--- a/amplikraken/test/testKrakenFunctions.py
+++ b/amplikraken/test/testKrakenFunctions.py
@@ -23,6 +23,11 @@ def test_taxonomy_fails_isint():
     z = '3'
     assert amplikraken.kraken.taxonomy_splitter(z) == (3, None)
 
+def test_taxonomy_fails_non_int_taxid():
+    z = 'Bacteria (taxid abc)'
+    with pytest.raises(Exception):
+        amplikraken.kraken.taxonomy_splitter(z)
+
 def test_kraken_record():
     # Create record from line, check its string representation is the same
     line = 'C	M00967:43:000000000-A3JHG:1:1101:17025:1426	2911	251|251	3:83 52:11 3:1 52:5 3:5 52:11 3:10 459:5 874:2 459:3 52:5 3:17 1:14 3:3 1:1 3:19 0:1 2882:4 3:17 |:| 3:43 1:1 3:3 1:36 3:15 0:10 2911:5 0:11 3:3 0:3 52:6 3:81'
@@ -35,8 +40,15 @@ def test_kraken_record_len():
     kr = amplikraken.kraken.KrakenRecord(line=line)
     assert len(kr) == 502
 
-def test_kraken_record_len():
+def test_kraken_record_len_invalid():
     # Wrong length, simply return 0
     line = 'C	M00967:43:000000000-A3JHG:1:1101:17025:1426	2911	x|x	3:83 52:11 3:1 52:5 3:5 52:11 3:10 459:5 874:2 459:3 52:5 3:17 1:14 3:3 1:1 3:19 0:1 2882:4 3:17 |:| 3:43 1:1 3:3 1:36 3:15 0:10 2911:5 0:11 3:3 0:3 52:6 3:81'
     kr = amplikraken.kraken.KrakenRecord(line=line)
     assert len(kr) == 0
+
+def test_fastqdataset_repr_and_eq():
+    from amplikraken.fastq import FastqDataset
+    ds1 = FastqDataset('s1', 'r1.fq', 'r2.fq')
+    ds2 = FastqDataset('s1', 'r1.fq', 'r2.fq')
+    assert isinstance(repr(ds1), str)
+    assert ds1 == ds2


### PR DESCRIPTION
## Summary
- fix `taxonomy_splitter` to properly report non-integer taxid
- fix `FastqDataset.__repr__` and `__eq__`
- extend tests for taxonomy errors and dataset equality

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_685cd997d8688330beeecc3867d0bf49